### PR TITLE
Fix cookie handling for downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # newgrounds-gallery-scraper
-A tool for pulling full resolution images from a user's newgrounds gallery.
+
+A browser extension for downloading full resolution images from a user's Newgrounds gallery.
+
+## Features
+
+- Works in Firefox and other browsers supporting the WebExtension API.
+- Allows the user to paste an exported login cookie in JSON format to access private galleries.
+- Dynamically adapts to Newgrounds rate limits when scraping.
+- Lets the user specify a download subfolder via the popup UI.
+
+## Usage
+
+1. Load the `extension` directory as a temporary extension in your browser.
+2. Open the options page and paste your cookie JSON if authentication is required.
+3. Navigate to a Newgrounds gallery and click the extension icon.
+4. Enter the desired output folder name and start the scrape.
+
+Images will be saved using the browser's downloads directory in the specified subfolder.

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,58 @@
+let rateLimitDelay = 1000; // start with 1 second between requests
+
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function fetchWithCookie(url, cookie) {
+  const headers = {};
+  if (cookie) {
+    headers['Cookie'] = cookie;
+  }
+  const response = await fetch(url, { credentials: 'include', headers });
+  if (response.status === 429) { // rate limited
+    rateLimitDelay = Math.min(rateLimitDelay + 500, 5000);
+    await delay(rateLimitDelay);
+    return fetchWithCookie(url, cookie);
+  } else {
+    rateLimitDelay = Math.max(1000, rateLimitDelay - 100);
+    return response;
+  }
+}
+
+async function downloadImage(url, filename, cookie) {
+  const blob = await fetchWithCookie(url, cookie).then(r => r.blob());
+  const objectUrl = URL.createObjectURL(blob);
+  await browser.downloads.download({
+    url: objectUrl,
+    filename,
+    saveAs: false
+  });
+  URL.revokeObjectURL(objectUrl);
+}
+
+async function scrapeGallery(tabId, folder, cookie) {
+  const tab = await browser.tabs.get(tabId);
+  if (!tab || !tab.url.includes('newgrounds.com')) {
+    return;
+  }
+  // Request DOM info from content script
+  const urls = await browser.tabs.executeScript(tabId, {
+    code: `Array.from(document.querySelectorAll('a[href$=".png"],a[href$=".jpg"],a[href$=".gif"]')).map(a => a.href)`
+  });
+  if (!urls || !urls[0]) return;
+  for (const url of urls[0]) {
+    const parts = url.split('/');
+    const filename = folder + '/' + parts[parts.length - 1];
+    await downloadImage(url, filename, cookie);
+    await delay(rateLimitDelay);
+  }
+}
+
+browser.runtime.onMessage.addListener((message, sender) => {
+  if (message.action === 'scrape') {
+    browser.storage.local.get(['cookie']).then(result => {
+      scrapeGallery(sender.tab.id, message.folder, result.cookie);
+    });
+  }
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,24 @@
+{
+  "manifest_version": 2,
+  "name": "Newgrounds Gallery Scraper",
+  "version": "0.1",
+  "description": "Download images from a user's Newgrounds gallery.",
+  "permissions": [
+    "activeTab",
+    "downloads",
+    "storage",
+    "https://*.newgrounds.com/*"
+  ],
+  "browser_action": {
+    "default_popup": "popup.html",
+    "default_title": "Scrape Gallery"
+  },
+  "background": {
+    "scripts": ["background.js"],
+    "persistent": false
+  },
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
+  }
+}

--- a/extension/options.html
+++ b/extension/options.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Scraper Options</title>
+  <style>
+    body { font-family: Arial, sans-serif; max-width: 400px; margin: 20px; }
+    textarea { width: 100%; height: 100px; }
+  </style>
+</head>
+<body>
+  <h2>Scraper Options</h2>
+  <label>
+    Paste cookie JSON:
+    <textarea id="cookie"></textarea>
+  </label>
+  <button id="save">Save</button>
+  <p id="msg"></p>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,0 +1,15 @@
+function $(id) { return document.getElementById(id); }
+
+document.addEventListener('DOMContentLoaded', () => {
+  const cookieArea = $('cookie');
+  browser.storage.local.get('cookie').then(result => {
+    if (result.cookie) cookieArea.value = result.cookie;
+  });
+
+  $('save').addEventListener('click', () => {
+    const cookie = cookieArea.value.trim();
+    browser.storage.local.set({ cookie }).then(() => {
+      $('msg').textContent = 'Saved.';
+    });
+  });
+});

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Gallery Scraper</title>
+  <style>
+    body { font-family: Arial, sans-serif; min-width: 250px; padding: 10px; }
+    label { display: block; margin-top: 10px; }
+  </style>
+</head>
+<body>
+  <h3>Newgrounds Scraper</h3>
+  <label>
+    Output folder:
+    <input type="text" id="folder" placeholder="e.g. my_gallery" />
+  </label>
+  <button id="scrape">Scrape this gallery</button>
+  <p id="status"></p>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,16 @@
+function $(id) { return document.getElementById(id); }
+
+document.addEventListener('DOMContentLoaded', () => {
+  const folderInput = $('folder');
+  // load saved folder
+  browser.storage.local.get('folder').then(result => {
+    if (result.folder) folderInput.value = result.folder;
+  });
+
+  $('scrape').addEventListener('click', () => {
+    const folder = folderInput.value.trim();
+    browser.storage.local.set({ folder });
+    browser.runtime.sendMessage({ action: 'scrape', folder });
+    $('status').textContent = 'Scraping started...';
+  });
+});


### PR DESCRIPTION
## Summary
- pass cookie to fetch requests so authenticated downloads work

## Testing
- `node --check extension/background.js`
- `npx web-ext lint --source-dir extension`

------
https://chatgpt.com/codex/tasks/task_e_6840a2a16e30832887133201c68b4b6e