### PR TITLE
Add basic Jest tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+package-lock.json
+npm-debug.log
+.DS_Store

--- a/extension/background.js
+++ b/extension/background.js
@@ -60,10 +60,25 @@ async function scrapeGallery(tabId, folder, cookie, fileTypes) {
   }
 }
 
-browser.runtime.onMessage.addListener((message, sender) => {
-  if (message.action === 'scrape') {
-    browser.storage.local.get(['cookie','fileTypes']).then(result => {
-      scrapeGallery(sender.tab.id, message.folder, result.cookie, result.fileTypes || {});
-    });
-  }
-});
+
+if (typeof browser !== 'undefined' &&
+    browser.runtime &&
+    browser.runtime.onMessage &&
+    typeof browser.runtime.onMessage.addListener === 'function') {
+  browser.runtime.onMessage.addListener((message, sender) => {
+    if (message.action === 'scrape') {
+      browser.storage.local.get(['cookie','fileTypes']).then(result => {
+        scrapeGallery(sender.tab.id, message.folder, result.cookie, result.fileTypes || {});
+      });
+    }
+  });
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = {
+    delay,
+    fetchWithCookie,
+    downloadFile,
+    scrapeGallery
+  };
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "newgrounds-gallery-scraper",
+  "version": "1.0.0",
+  "description": "A browser extension for downloading full resolution images from a user's Newgrounds gallery.",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/test/background.test.js
+++ b/test/background.test.js
@@ -1,0 +1,21 @@
+const {delay, fetchWithCookie} = require('../extension/background');
+
+describe('delay function', () => {
+  test('resolves after given milliseconds', async () => {
+    const start = Date.now();
+    await delay(100);
+    const duration = Date.now() - start;
+    expect(duration).toBeGreaterThanOrEqual(100);
+  });
+});
+
+describe('fetchWithCookie', () => {
+  test('sends cookie header when provided', async () => {
+    global.fetch = jest.fn().mockResolvedValue({status: 200});
+    await fetchWithCookie('http://example.com', 'foo=bar');
+    expect(global.fetch).toHaveBeenCalledWith('http://example.com', {
+      credentials: 'include',
+      headers: { Cookie: 'foo=bar' }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- create `.gitignore` so `node_modules` and package-lock aren't committed
- update `background.js` to safely register runtime listener and export functions for tests
- add `package.json` with Jest setup
- add simple unit tests for `delay` and `fetchWithCookie`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840a799507c8328a372387fa629c4fd