### PR TITLE
Fix Chrome extension errors

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Newgrounds Gallery Scraper",
   "version": "0.1",
   "description": "Download images from a user's Newgrounds gallery.",
@@ -7,15 +7,17 @@
     "activeTab",
     "downloads",
     "storage",
+    "scripting"
+  ],
+  "host_permissions": [
     "https://*.newgrounds.com/*"
   ],
-  "browser_action": {
+  "action": {
     "default_popup": "popup.html",
     "default_title": "Scrape Gallery"
   },
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
   "options_ui": {
     "page": "options.html",

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,3 +1,7 @@
+if (typeof browser === 'undefined' && typeof chrome !== 'undefined') {
+  var browser = chrome;
+}
+
 function $(id) { return document.getElementById(id); }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,3 +1,7 @@
+if (typeof browser === 'undefined' && typeof chrome !== 'undefined') {
+  var browser = chrome;
+}
+
 function $(id) { return document.getElementById(id); }
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- upgrade manifest to version 3
- fallback to `chrome` namespace for compatibility
- support MV3 script injection via the `scripting` API

## Testing
- `npm install`
- `npm test`

------