### PR TITLE
Fix CORS when scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ A browser extension for downloading full resolution images from a user's Newgrou
 ## Features
 
 - Works in Firefox and other browsers supporting the WebExtension API.
-- Allows the user to paste an exported login cookie in JSON format to access private galleries.
+- Allows the user to paste an exported login cookie in JSON format to access private galleries. The cookies are stored via the browser API so authenticated requests work correctly.
 - Dynamically adapts to Newgrounds rate limits when scraping.
+- Modifies request and response headers so images can be downloaded without CORS errors.
 - Lets the user specify a download subfolder via the popup UI.
 - Displays progress for each downloaded file in the popup.
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -7,10 +7,14 @@
     "activeTab",
     "downloads",
     "storage",
-    "scripting"
+    "scripting",
+    "cookies",
+    "webRequest",
+    "webRequestBlocking"
   ],
   "host_permissions": [
-    "https://*.newgrounds.com/*"
+    "https://*.newgrounds.com/*",
+    "https://*.ngfiles.com/*"
   ],
   "action": {
     "default_popup": "popup.html",

--- a/test/background.test.js
+++ b/test/background.test.js
@@ -10,12 +10,39 @@ describe('delay function', () => {
 });
 
 describe('fetchWithCookie', () => {
-  test('sends cookie header when provided', async () => {
+  test('uses fetch with credentials', async () => {
     global.fetch = jest.fn().mockResolvedValue({status: 200});
-    await fetchWithCookie('http://example.com', 'foo=bar');
+    await fetchWithCookie('http://example.com');
     expect(global.fetch).toHaveBeenCalledWith('http://example.com', {
-      credentials: 'include',
-      headers: { Cookie: 'foo=bar' }
+      credentials: 'include'
     });
+  });
+
+  test('uses XMLHttpRequest when available', async () => {
+    const open = jest.fn();
+    const send = jest.fn(function() {
+      this.status = 200;
+      this.statusText = 'OK';
+      this.response = 'data';
+      if (this.onload) this.onload();
+    });
+    function FakeXHR() {
+      this.open = open;
+      this.send = send;
+    }
+    const xhrInstance = new FakeXHR();
+    global.XMLHttpRequest = jest.fn(() => xhrInstance);
+    global.fetch = jest.fn();
+
+    const res = await fetchWithCookie('http://example.com/resource');
+
+    expect(global.XMLHttpRequest).toHaveBeenCalled();
+    expect(open).toHaveBeenCalledWith('GET', 'http://example.com/resource', true);
+    expect(xhrInstance.responseType).toBe('blob');
+    expect(xhrInstance.withCredentials).toBe(true);
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+
+    delete global.XMLHttpRequest;
   });
 });


### PR DESCRIPTION
## Summary
- spoof Origin and Access-Control headers to bypass CORS
- add ngfiles host permission
- test XMLHttpRequest fallback

## Testing
- `npm install`
- `npm test`


------